### PR TITLE
fix: notification auto-cancel and settings sync

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,11 @@ def static releaseTime() {
     return new Date().format("yyMMdd", TimeZone.default)
 }
 
+def randomHex8() {
+    def r = new java.security.SecureRandom()
+    return String.format("%08x", r.nextInt() & 0xffffffffL)
+}
+
 def VERSION_NAME = "3.0.4"
 def VERSION_CODE = 66
 
@@ -74,6 +79,7 @@ android {
         debug {
             buildConfigField("int", "LOG_LEVEL", "2")
             buildConfigField("boolean", "LOG_TO_XPOSED", "true")
+            versionNameSuffix "-${randomHex8()}"
 
             if (isSigningInfoAvailable) {
                 signingConfig = signingConfigs.release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     // Compose
     implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.ui
+    implementation libs.androidx.material
     implementation libs.androidx.material3
     implementation libs.androidx.material.icons.core
     implementation libs.androidx.material.icons.extended

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,10 @@
                 android:resource="@xml/files" />
         </provider>
 
+        <receiver
+            android:name="com.tianma.xsmscode.xp.hook.code.AutoCancelReceiver"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,6 +96,11 @@
             android:exported="true" />
 
         <provider
+            android:name="com.tianma.xsmscode.data.prefs.PrefsProvider"
+            android:authorities="${applicationId}.pref.provider"
+            android:exported="true" />
+
+        <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.files"
             android:exported="false"
@@ -104,6 +109,7 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/files" />
         </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tianma/xsmscode/common/utils/AppPreferencesDataStore.kt
+++ b/app/src/main/java/com/tianma/xsmscode/common/utils/AppPreferencesDataStore.kt
@@ -14,10 +14,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.io.File
+import android.content.SharedPreferences
 
 object AppPreferencesDataStore {
     private val backupCompatTipShownKey = booleanPreferencesKey(PrefConst.KEY_BACKUP_COMPAT_TIP_SHOWN)
     private const val DATASTORE_FILE_NAME = "app_preferences.preferences_pb"
+    private const val SHARED_PREFS_FILE_NAME = "xposed_prefs"
 
     @Volatile
     private var INSTANCE: DataStore<Preferences>? = null
@@ -36,13 +38,27 @@ object AppPreferencesDataStore {
         return File(context.dataDir, "datastore/$DATASTORE_FILE_NAME")
     }
 
+    private fun getSharedPrefsFile(context: Context): File {
+        return File(context.dataDir, "shared_prefs/$SHARED_PREFS_FILE_NAME.xml")
+    }
+
+    private fun getSharedPrefs(context: Context): SharedPreferences {
+        return context.getSharedPreferences(SHARED_PREFS_FILE_NAME, Context.MODE_PRIVATE)
+    }
+
     private fun ensureDataStoreReadable(context: Context) {
         val file = getDataStoreFile(context)
         StorageUtils.setFileWorldReadable(file, 3)
     }
 
+    private fun ensureSharedPrefsReadable(context: Context) {
+        val file = getSharedPrefsFile(context)
+        StorageUtils.setFileWorldReadable(file, 3)
+    }
+
     fun ensureReadable(context: Context) {
         ensureDataStoreReadable(context)
+        ensureSharedPrefsReadable(context)
     }
 
     suspend fun isBackupCompatTipShown(context: Context): Boolean {
@@ -55,7 +71,9 @@ object AppPreferencesDataStore {
         getInstance(context).edit { prefs ->
             prefs[backupCompatTipShownKey] = shown
         }
+        getSharedPrefs(context).edit().putBoolean(PrefConst.KEY_BACKUP_COMPAT_TIP_SHOWN, shown).apply()
         ensureDataStoreReadable(context)
+        ensureSharedPrefsReadable(context)
     }
 
     suspend fun getBoolean(context: Context, key: String, defaultValue: Boolean): Boolean {
@@ -70,7 +88,9 @@ object AppPreferencesDataStore {
         getInstance(context).edit { prefs ->
             prefs[prefKey] = value
         }
+        getSharedPrefs(context).edit().putBoolean(key, value).apply()
         ensureDataStoreReadable(context)
+        ensureSharedPrefsReadable(context)
     }
 
     suspend fun getString(context: Context, key: String, defaultValue: String): String {
@@ -85,7 +105,9 @@ object AppPreferencesDataStore {
         getInstance(context).edit { prefs ->
             prefs[prefKey] = value
         }
+        getSharedPrefs(context).edit().putString(key, value).apply()
         ensureDataStoreReadable(context)
+        ensureSharedPrefsReadable(context)
     }
 
     suspend fun getInt(context: Context, key: String, defaultValue: Int): Int {
@@ -100,7 +122,59 @@ object AppPreferencesDataStore {
         getInstance(context).edit { prefs ->
             prefs[prefKey] = value
         }
+        getSharedPrefs(context).edit().putInt(key, value).apply()
         ensureDataStoreReadable(context)
+        ensureSharedPrefsReadable(context)
+    }
+
+    suspend fun getBooleanCompat(context: Context, key: String, defaultValue: Boolean): Boolean {
+        val sharedPrefs = getSharedPrefs(context)
+        return if (sharedPrefs.contains(key)) {
+            sharedPrefs.getBoolean(key, defaultValue)
+        } else {
+            getBoolean(context, key, defaultValue)
+        }
+    }
+
+    suspend fun getStringCompat(context: Context, key: String, defaultValue: String): String {
+        val sharedPrefs = getSharedPrefs(context)
+        return if (sharedPrefs.contains(key)) {
+            sharedPrefs.getString(key, defaultValue) ?: defaultValue
+        } else {
+            getString(context, key, defaultValue)
+        }
+    }
+
+    suspend fun getIntCompat(context: Context, key: String, defaultValue: Int): Int {
+        val sharedPrefs = getSharedPrefs(context)
+        return if (sharedPrefs.contains(key)) {
+            sharedPrefs.getInt(key, defaultValue)
+        } else {
+            getInt(context, key, defaultValue)
+        }
+    }
+
+    suspend fun syncToSharedPrefs(context: Context) {
+        val editor = getSharedPrefs(context).edit()
+        editor.putBoolean(PrefConst.KEY_ENABLE, getBoolean(context, PrefConst.KEY_ENABLE, true))
+        editor.putBoolean(PrefConst.KEY_VERBOSE_LOG_MODE, getBoolean(context, PrefConst.KEY_VERBOSE_LOG_MODE, false))
+        editor.putBoolean(PrefConst.KEY_ENABLE_AUTO_INPUT_CODE, getBoolean(context, PrefConst.KEY_ENABLE_AUTO_INPUT_CODE, true))
+        editor.putString(PrefConst.KEY_AUTO_INPUT_CODE_DELAY, getString(context, PrefConst.KEY_AUTO_INPUT_CODE_DELAY, PrefConst.KEY_AUTO_INPUT_CODE_DELAY_DEFAULT))
+        editor.putBoolean(PrefConst.KEY_SHOW_TOAST, getBoolean(context, PrefConst.KEY_SHOW_TOAST, true))
+        editor.putString(PrefConst.KEY_SMSCODE_KEYWORDS, getString(context, PrefConst.KEY_SMSCODE_KEYWORDS, PrefConst.SMSCODE_KEYWORDS_DEFAULT))
+        editor.putBoolean(PrefConst.KEY_MARK_AS_READ, getBoolean(context, PrefConst.KEY_MARK_AS_READ, false))
+        editor.putBoolean(PrefConst.KEY_DELETE_SMS, getBoolean(context, PrefConst.KEY_DELETE_SMS, false))
+        editor.putBoolean(PrefConst.KEY_COPY_TO_CLIPBOARD, getBoolean(context, PrefConst.KEY_COPY_TO_CLIPBOARD, true))
+        editor.putBoolean(PrefConst.KEY_ENABLE_CODE_RECORDS, getBoolean(context, PrefConst.KEY_ENABLE_CODE_RECORDS, true))
+        editor.putBoolean(PrefConst.KEY_BLOCK_SMS, getBoolean(context, PrefConst.KEY_BLOCK_SMS, false))
+        editor.putBoolean(PrefConst.KEY_KILL_ME, getBoolean(context, PrefConst.KEY_KILL_ME, false))
+        editor.putBoolean(PrefConst.KEY_SHOW_CODE_NOTIFICATION, getBoolean(context, PrefConst.KEY_SHOW_CODE_NOTIFICATION, true))
+        editor.putBoolean(PrefConst.KEY_AUTO_CANCEL_CODE_NOTIFICATION, getBoolean(context, PrefConst.KEY_AUTO_CANCEL_CODE_NOTIFICATION, false))
+        editor.putString(PrefConst.KEY_NOTIFICATION_RETENTION_TIME, getString(context, PrefConst.KEY_NOTIFICATION_RETENTION_TIME, PrefConst.NOTIFICATION_RETENTION_TIME_DEFAULT))
+        editor.putBoolean(PrefConst.KEY_DEDUPLICATE_SMS, getBoolean(context, PrefConst.KEY_DEDUPLICATE_SMS, true))
+        editor.putString(PrefConst.KEY_HISTORY_LIMIT, getString(context, PrefConst.KEY_HISTORY_LIMIT, "0"))
+        editor.apply()
+        ensureSharedPrefsReadable(context)
     }
 
     fun getBooleanFlow(context: Context, key: String, defaultValue: Boolean): Flow<Boolean> {

--- a/app/src/main/java/com/tianma/xsmscode/common/utils/PrefsReader.kt
+++ b/app/src/main/java/com/tianma/xsmscode/common/utils/PrefsReader.kt
@@ -6,31 +6,83 @@ import com.tianma.xsmscode.common.constant.PrefConst
 import kotlinx.coroutines.runBlocking
 
 object PrefsReader {
+    private fun getBooleanViaProvider(context: Context, key: String, defaultValue: Boolean): Boolean {
+        return try {
+            val uri = com.tianma.xsmscode.data.prefs.PrefsProvider.BOOL_URI.buildUpon()
+                .appendQueryParameter("key", key)
+                .appendQueryParameter("default", defaultValue.toString())
+                .build()
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val value = cursor.getString(0)
+                    return value == "1" || value.equals("true", ignoreCase = true)
+                }
+            }
+            defaultValue
+        } catch (t: Throwable) {
+            defaultValue
+        }
+    }
+
+    private fun getStringViaProvider(context: Context, key: String, defaultValue: String): String {
+        return try {
+            val uri = com.tianma.xsmscode.data.prefs.PrefsProvider.STRING_URI.buildUpon()
+                .appendQueryParameter("key", key)
+                .appendQueryParameter("default", defaultValue)
+                .build()
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    return cursor.getString(0) ?: defaultValue
+                }
+            }
+            defaultValue
+        } catch (t: Throwable) {
+            defaultValue
+        }
+    }
+
+    private fun getIntViaProvider(context: Context, key: String, defaultValue: Int): Int {
+        return try {
+            val uri = com.tianma.xsmscode.data.prefs.PrefsProvider.INT_URI.buildUpon()
+                .appendQueryParameter("key", key)
+                .appendQueryParameter("default", defaultValue.toString())
+                .build()
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    return cursor.getString(0)?.toIntOrNull() ?: defaultValue
+                }
+            }
+            defaultValue
+        } catch (t: Throwable) {
+            defaultValue
+        }
+    }
 
     @JvmStatic
     fun isEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_ENABLE, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_ENABLE, defaultValue)
     }
 
     @JvmStatic
     fun isVerboseLogMode(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_VERBOSE_LOG_MODE, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_VERBOSE_LOG_MODE, defaultValue)
     }
 
     @JvmStatic
     fun autoInputCodeEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_ENABLE_AUTO_INPUT_CODE, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_ENABLE_AUTO_INPUT_CODE, defaultValue)
     }
 
     @JvmStatic
     fun getAutoInputCodeDelay(context: Context): Long {
-        val value = runBlocking {
-            AppPreferencesDataStore.getString(
-                context,
-                PrefConst.KEY_AUTO_INPUT_CODE_DELAY,
-                PrefConst.KEY_AUTO_INPUT_CODE_DELAY_DEFAULT
-            )
-        }
+        val value = getStringViaProvider(
+            context,
+            PrefConst.KEY_AUTO_INPUT_CODE_DELAY,
+            PrefConst.KEY_AUTO_INPUT_CODE_DELAY_DEFAULT
+        )
         return try {
             value.toLong()
         } catch (e: Exception) {
@@ -40,69 +92,74 @@ object PrefsReader {
 
     @JvmStatic
     fun shouldShowToast(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_SHOW_TOAST, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_SHOW_TOAST, defaultValue)
     }
 
     @JvmStatic
     fun getSMSCodeKeywords(context: Context): String? {
-        return runBlocking {
-            AppPreferencesDataStore.getString(
-                context,
-                PrefConst.KEY_SMSCODE_KEYWORDS,
-                PrefConst.SMSCODE_KEYWORDS_DEFAULT
-            )
-        }
+        return getStringViaProvider(
+            context,
+            PrefConst.KEY_SMSCODE_KEYWORDS,
+            PrefConst.SMSCODE_KEYWORDS_DEFAULT
+        )
     }
 
     @JvmStatic
     fun markAsReadEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_MARK_AS_READ, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_MARK_AS_READ, defaultValue)
     }
 
     @JvmStatic
     fun deleteSmsEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_DELETE_SMS, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_DELETE_SMS, defaultValue)
     }
 
     @JvmStatic
     fun copyToClipboardEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_COPY_TO_CLIPBOARD, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_COPY_TO_CLIPBOARD, defaultValue)
     }
 
     @JvmStatic
     fun recordSmsCodeEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_ENABLE_CODE_RECORDS, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_ENABLE_CODE_RECORDS, defaultValue)
     }
 
     @JvmStatic
     fun blockSmsEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_BLOCK_SMS, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_BLOCK_SMS, defaultValue)
     }
 
     @JvmStatic
     fun killMeEnabled(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_KILL_ME, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_KILL_ME, defaultValue)
     }
 
     @JvmStatic
     fun showCodeNotification(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_SHOW_CODE_NOTIFICATION, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_SHOW_CODE_NOTIFICATION, defaultValue)
     }
 
     @JvmStatic
     fun autoCancelCodeNotification(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_AUTO_CANCEL_CODE_NOTIFICATION, false) }
+        val defaultValue = false
+        return getBooleanViaProvider(context, PrefConst.KEY_AUTO_CANCEL_CODE_NOTIFICATION, defaultValue)
     }
 
     @JvmStatic
     fun getNotificationRetentionTime(context: Context): Int {
-        val value = runBlocking {
-            AppPreferencesDataStore.getString(
-                context,
-                PrefConst.KEY_NOTIFICATION_RETENTION_TIME,
-                PrefConst.NOTIFICATION_RETENTION_TIME_DEFAULT
-            )
-        }
+        val value = getStringViaProvider(
+            context,
+            PrefConst.KEY_NOTIFICATION_RETENTION_TIME,
+            PrefConst.NOTIFICATION_RETENTION_TIME_DEFAULT
+        )
         return try {
             value.toInt()
         } catch (e: Exception) {
@@ -112,18 +169,17 @@ object PrefsReader {
 
     @JvmStatic
     fun deduplicateSms(context: Context): Boolean {
-        return runBlocking { AppPreferencesDataStore.getBoolean(context, PrefConst.KEY_DEDUPLICATE_SMS, true) }
+        val defaultValue = true
+        return getBooleanViaProvider(context, PrefConst.KEY_DEDUPLICATE_SMS, defaultValue)
     }
 
     @JvmStatic
     fun getHistoryLimit(context: Context): Int {
-        val value = runBlocking {
-            AppPreferencesDataStore.getString(
-                context,
-                PrefConst.KEY_HISTORY_LIMIT,
-                "0"
-            )
-        }
+        val value = getStringViaProvider(
+            context,
+            PrefConst.KEY_HISTORY_LIMIT,
+            "0"
+        )
         return try {
             value.toInt()
         } catch (e: Exception) {

--- a/app/src/main/java/com/tianma/xsmscode/data/prefs/PrefsProvider.kt
+++ b/app/src/main/java/com/tianma/xsmscode/data/prefs/PrefsProvider.kt
@@ -1,0 +1,87 @@
+package com.tianma.xsmscode.data.prefs
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import com.github.tianma8023.xposed.smscode.BuildConfig
+import com.tianma.xsmscode.common.utils.AppPreferencesDataStore
+import kotlinx.coroutines.runBlocking
+
+class PrefsProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? {
+        val type = sUriMatcher.match(uri)
+        val key = uri.getQueryParameter("key") ?: return null
+        val defaultValue = uri.getQueryParameter("default")
+        val cursor = MatrixCursor(arrayOf(COLUMN_VALUE))
+        val ctx = context ?: return cursor
+
+        when (type) {
+            TYPE_BOOL -> {
+                val def = defaultValue?.toBooleanStrictOrNull() ?: false
+                val value = runBlocking { AppPreferencesDataStore.getBoolean(ctx, key, def) }
+                cursor.addRow(arrayOf(if (value) "1" else "0"))
+            }
+            TYPE_STRING -> {
+                val def = defaultValue ?: ""
+                val value = runBlocking { AppPreferencesDataStore.getString(ctx, key, def) }
+                cursor.addRow(arrayOf(value))
+            }
+            TYPE_INT -> {
+                val def = defaultValue?.toIntOrNull() ?: 0
+                val value = runBlocking { AppPreferencesDataStore.getInt(ctx, key, def) }
+                cursor.addRow(arrayOf(value.toString()))
+            }
+            else -> return null
+        }
+        return cursor
+    }
+
+    companion object {
+        const val AUTHORITY = BuildConfig.APPLICATION_ID + ".pref.provider"
+        private const val PATH_BOOL = "bool"
+        private const val PATH_STRING = "string"
+        private const val PATH_INT = "int"
+        private const val TYPE_BOOL = 1
+        private const val TYPE_STRING = 2
+        private const val TYPE_INT = 3
+        private const val COLUMN_VALUE = "value"
+
+        private val sUriMatcher: UriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+            addURI(AUTHORITY, PATH_BOOL, TYPE_BOOL)
+            addURI(AUTHORITY, PATH_STRING, TYPE_STRING)
+            addURI(AUTHORITY, PATH_INT, TYPE_INT)
+        }
+
+        @JvmField
+        val BOOL_URI: Uri = Uri.parse("content://$AUTHORITY/$PATH_BOOL")
+        @JvmField
+        val STRING_URI: Uri = Uri.parse("content://$AUTHORITY/$PATH_STRING")
+        @JvmField
+        val INT_URI: Uri = Uri.parse("content://$AUTHORITY/$PATH_INT")
+    }
+}

--- a/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
+++ b/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
@@ -23,7 +23,8 @@ object EntityStoreManager {
     private val BLOCKED_APPS_FILE_NAME = "blocked_apps"
     private val PREV_CODE_RECORD = "prev_code_record"
 
-    private fun getStoreFile(context: Context, entityType: EntityType): File {
+    @PublishedApi
+    internal fun getStoreFile(context: Context, entityType: EntityType): File {
         val filename = when (entityType) {
             EntityType.BLOCKED_APP -> BLOCKED_APPS_FILE_NAME
             EntityType.CODE_RULES -> CODE_RULES_FILE_NAME

--- a/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
+++ b/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
@@ -33,8 +33,8 @@ object EntityStoreManager {
         return File(StorageUtils.getFilesDir(context), filename)
     }
 
-    @JvmStatic
-    fun <T> storeEntitiesToFile(context: Context, entityType: EntityType, entities: List<T>): Boolean {
+    //@JvmStatic // Removed for inline
+    inline fun <reified T> storeEntitiesToFile(context: Context, entityType: EntityType, entities: List<T>): Boolean {
         var osw: OutputStreamWriter? = null
         try {
             val storeFile = getStoreFile(context, entityType)
@@ -59,8 +59,8 @@ object EntityStoreManager {
         return false
     }
 
-    @JvmStatic
-    fun <T> storeEntityToFile(context: Context, entityType: EntityType, entity: T): Boolean {
+    //@JvmStatic // Removed for inline
+    inline fun <reified T> storeEntityToFile(context: Context, entityType: EntityType, entity: T): Boolean {
         val entities = ArrayList<T>()
         entities.add(entity)
         return storeEntitiesToFile(context, entityType, entities)

--- a/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
+++ b/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
@@ -35,14 +35,18 @@ object EntityStoreManager {
     }
 
     //@JvmStatic // Removed for inline
-    inline fun <reified T> storeEntitiesToFile(context: Context, entityType: EntityType, entities: List<T>): Boolean {
+    @JvmStatic
+    fun <T : Any> storeEntitiesToFile(context: Context, entityType: EntityType, entities: List<T>, clazz: Class<T>): Boolean {
         var osw: OutputStreamWriter? = null
         try {
             val storeFile = getStoreFile(context, entityType)
+            // Truncate file first
+            val jsonString = JsonUtils.listToJson(entities, clazz)
+            if (jsonString.isEmpty()) return false
+
             osw = OutputStreamWriter(FileOutputStream(storeFile), StandardCharsets.UTF_8)
-
-            JsonUtils.toJson(entities, osw, true)
-
+            osw.write(jsonString)
+            
             // set file world writable
             StorageUtils.setFileWorldWritable(storeFile, 0)
             return true
@@ -61,10 +65,11 @@ object EntityStoreManager {
     }
 
     //@JvmStatic // Removed for inline
-    inline fun <reified T> storeEntityToFile(context: Context, entityType: EntityType, entity: T): Boolean {
+    @JvmStatic
+    fun <T : Any> storeEntityToFile(context: Context, entityType: EntityType, entity: T, clazz: Class<T>): Boolean {
         val entities = ArrayList<T>()
         entities.add(entity)
-        return storeEntitiesToFile(context, entityType, entities)
+        return storeEntitiesToFile(context, entityType, entities, clazz)
     }
 
     @JvmStatic

--- a/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
+++ b/app/src/main/java/com/tianma/xsmscode/feature/store/EntityStoreManager.kt
@@ -78,6 +78,9 @@ object EntityStoreManager {
         if (!storeFile.exists()) {
             return ArrayList()
         }
+        if (storeFile.length() == 0L) {
+            return ArrayList()
+        }
         var isr: InputStreamReader? = null
         try {
             isr = InputStreamReader(

--- a/app/src/main/java/com/tianma/xsmscode/ui/app/SmsCodeApplication.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/app/SmsCodeApplication.kt
@@ -2,6 +2,7 @@ package com.tianma.xsmscode.ui.app
 
 import android.app.Application
 import com.tianma.xsmscode.feature.migrate.TransitionTask
+import com.tianma.xsmscode.common.utils.AppPreferencesDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -27,7 +28,15 @@ class SmsCodeApplication : Application() {
             androidContext(this@SmsCodeApplication)
             modules(appModule)
         }
+        syncPreferences()
         performTransitionTask()
+    }
+
+    private fun syncPreferences() {
+        applicationScope.launch {
+            AppPreferencesDataStore.syncToSharedPrefs(this@SmsCodeApplication)
+            AppPreferencesDataStore.ensureReadable(this@SmsCodeApplication)
+        }
     }
 
     private fun performTransitionTask() {

--- a/app/src/main/java/com/tianma/xsmscode/ui/block/AppBlockViewModel.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/block/AppBlockViewModel.kt
@@ -219,7 +219,7 @@ class AppBlockViewModel(application: Application) : AndroidViewModel(application
                     dbManager.insertOrReplaceInTxSuspend(AppInfo::class.java, blockedApps)
                     
                     EntityStoreManager.storeEntitiesToFile(
-                        getApplication(), EntityType.BLOCKED_APP, blockedApps
+                        getApplication(), EntityType.BLOCKED_APP, blockedApps, AppInfo::class.java
                     )
                 }
                 // Update original checks

--- a/app/src/main/java/com/tianma/xsmscode/ui/home/ComposeSettingsScreen.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/home/ComposeSettingsScreen.kt
@@ -335,7 +335,11 @@ fun ComposeSettingsScreen(
                         showHistoryLimitInput = true
                     } else {
                         historyLimit = value
-                        scope.launch { AppPreferencesDataStore.setString(context, PrefConst.KEY_HISTORY_LIMIT, value) }
+                        scope.launch {
+                            AppPreferencesDataStore.setString(context, PrefConst.KEY_HISTORY_LIMIT, value)
+                            AppPreferencesDataStore.syncToSharedPrefs(context)
+                            Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+                        }
                     }
                     showHistoryLimitDialog = false
                 }
@@ -349,7 +353,11 @@ fun ComposeSettingsScreen(
                 ) { value ->
                    if (value.all { it.isDigit() } && value.isNotEmpty()) {
                        historyLimit = value
-                       scope.launch { AppPreferencesDataStore.setString(context, PrefConst.KEY_HISTORY_LIMIT, value) }
+                       scope.launch {
+                           AppPreferencesDataStore.setString(context, PrefConst.KEY_HISTORY_LIMIT, value)
+                           AppPreferencesDataStore.syncToSharedPrefs(context)
+                           Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+                       }
                    }
                    showHistoryLimitInput = false
                 }
@@ -403,7 +411,11 @@ fun ComposeSettingsScreen(
             onDismiss = { showAutoInputDialog = false }
         ) { value ->
             autoInputDelay = value
-            scope.launch { AppPreferencesDataStore.setString(context, PrefConst.KEY_AUTO_INPUT_CODE_DELAY, value) }
+            scope.launch {
+                AppPreferencesDataStore.setString(context, PrefConst.KEY_AUTO_INPUT_CODE_DELAY, value)
+                AppPreferencesDataStore.syncToSharedPrefs(context)
+                Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+            }
             showAutoInputDialog = false
         }
     }
@@ -414,7 +426,11 @@ fun ComposeSettingsScreen(
             onDismiss = { showRetentionDialog = false }
         ) { value ->
             retentionTime = value
-            scope.launch { AppPreferencesDataStore.setString(context, PrefConst.KEY_NOTIFICATION_RETENTION_TIME, value) }
+            scope.launch {
+                AppPreferencesDataStore.setString(context, PrefConst.KEY_NOTIFICATION_RETENTION_TIME, value)
+                AppPreferencesDataStore.syncToSharedPrefs(context)
+                Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+            }
             showRetentionDialog = false
         }
     }
@@ -443,7 +459,11 @@ fun ComposeSettingsScreen(
         ) { value ->
             val updated = if (value.isBlank()) PrefConst.SMSCODE_KEYWORDS_DEFAULT else value
             smsCodeKeywords = updated
-            scope.launch { AppPreferencesDataStore.setString(context, PrefConst.KEY_SMSCODE_KEYWORDS, updated) }
+            scope.launch {
+                AppPreferencesDataStore.setString(context, PrefConst.KEY_SMSCODE_KEYWORDS, updated)
+                AppPreferencesDataStore.syncToSharedPrefs(context)
+                Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+            }
             showKeywordsDialog = false
         }
     }
@@ -573,7 +593,11 @@ fun SwitchItem(
 
     fun toggle(checked: Boolean) {
         checkedState.value = checked
-        scope.launch { AppPreferencesDataStore.setBoolean(context, key, checked) }
+        scope.launch {
+            AppPreferencesDataStore.setBoolean(context, key, checked)
+            AppPreferencesDataStore.syncToSharedPrefs(context)
+            Toast.makeText(context, context.getString(R.string.pref_sync_toast), Toast.LENGTH_SHORT).show()
+        }
         onToggle?.invoke(checked)
     }
 

--- a/app/src/main/java/com/tianma/xsmscode/ui/home/SettingsViewModel.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/home/SettingsViewModel.kt
@@ -65,6 +65,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val mode = SPUtils.getThemeMode(getApplication())
             _themeState.value = ThemeState(mode)
         }
+        viewModelScope.launch {
+            AppPreferencesDataStore.syncToSharedPrefs(getApplication())
+        }
     }
 
     fun setThemeMode(mode: Int, x: Float = -1f, y: Float = -1f) {

--- a/app/src/main/java/com/tianma/xsmscode/ui/record/CodeRecordScreen.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/record/CodeRecordScreen.kt
@@ -14,6 +14,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.DismissValue
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeToDismiss
+import androidx.compose.material.rememberDismissState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -40,7 +45,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import java.text.SimpleDateFormat
 import java.util.*
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun CodeRecordScreen(
     onBack: () -> Unit,
@@ -245,34 +250,89 @@ fun CodeRecordScreen(
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(list, key = { it.id ?: 0 }) { smsMsg ->
                             val isSelected = selectedIds.contains(smsMsg.id)
-                            CodeRecordItem(
-                                smsMsg = smsMsg,
-                                isSelectionMode = isSelectionMode,
-                                isSelected = isSelected,
-                                onClick = {
-                                    if (isSelectionMode) {
+                            val deleteAndUndo: (SmsMsg) -> Unit = { target ->
+                                viewModel.removeSmsMsg(listOf(target))
+                                scope.launch {
+                                    val result = snackbarHostState.showSnackbar(
+                                        message = context.getString(R.string.some_items_removed, 1),
+                                        actionLabel = context.getString(R.string.revoke),
+                                        duration = SnackbarDuration.Long
+                                    )
+                                    if (result == SnackbarResult.ActionPerformed) {
+                                        viewModel.restoreSmsMsgList(listOf(target))
+                                    }
+                                }
+                            }
+
+                            if (isSelectionMode) {
+                                CodeRecordItem(
+                                    smsMsg = smsMsg,
+                                    isSelectionMode = isSelectionMode,
+                                    isSelected = isSelected,
+                                    onClick = {
                                         toggleSelection(smsMsg.id ?: 0)
-                                    } else {
-                                        val code = smsMsg.smsCode
-                                        if (!code.isNullOrEmpty()) {
-                                            clipboardManager.setText(AnnotatedString(code))
-                                            scope.launch {
-                                                snackbarHostState.showSnackbar(context.getString(R.string.prompt_sms_code_copied, code))
+                                    },
+                                    onLongClick = {},
+                                    onDetailClick = {
+                                        detailSmsMsg = smsMsg
+                                    },
+                                    modifier = Modifier.animateItem()
+                                )
+                            } else {
+                                val dismissState = rememberDismissState(confirmStateChange = { value ->
+                                    if (value == DismissValue.DismissedToEnd || value == DismissValue.DismissedToStart) {
+                                        deleteAndUndo(smsMsg)
+                                    }
+                                    true
+                                })
+                                SwipeToDismiss(
+                                    state = dismissState,
+                                    directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
+                                    background = {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .background(MaterialTheme.colorScheme.errorContainer)
+                                                .padding(horizontal = 24.dp),
+                                            contentAlignment = if (dismissState.dismissDirection == DismissDirection.StartToEnd) {
+                                                Alignment.CenterStart
+                                            } else {
+                                                Alignment.CenterEnd
                                             }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Delete,
+                                                contentDescription = stringResource(R.string.remove),
+                                                tint = MaterialTheme.colorScheme.onErrorContainer
+                                            )
                                         }
+                                    },
+                                    dismissContent = {
+                                        CodeRecordItem(
+                                            smsMsg = smsMsg,
+                                            isSelectionMode = false,
+                                            isSelected = isSelected,
+                                            onClick = {
+                                                val code = smsMsg.smsCode
+                                                if (!code.isNullOrEmpty()) {
+                                                    clipboardManager.setText(AnnotatedString(code))
+                                                    scope.launch {
+                                                        snackbarHostState.showSnackbar(context.getString(R.string.prompt_sms_code_copied, code))
+                                                    }
+                                                }
+                                            },
+                                            onLongClick = {
+                                                isSelectionMode = true
+                                                toggleSelection(smsMsg.id ?: 0)
+                                            },
+                                            onDetailClick = {
+                                                detailSmsMsg = smsMsg
+                                            },
+                                            modifier = Modifier.animateItem()
+                                        )
                                     }
-                                },
-                                onLongClick = {
-                                    if (!isSelectionMode) {
-                                        isSelectionMode = true
-                                        toggleSelection(smsMsg.id ?: 0)
-                                    }
-                                },
-                                onDetailClick = {
-                                    detailSmsMsg = smsMsg
-                                },
-                                modifier = Modifier.animateItem()
-                            )
+                                )
+                            }
                             HorizontalDivider()
                         }
                     }

--- a/app/src/main/java/com/tianma/xsmscode/ui/rule/edit/RuleEditViewModel.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/rule/edit/RuleEditViewModel.kt
@@ -98,7 +98,9 @@ class RuleEditViewModel(application: Application) : AndroidViewModel(application
     fun saveAsTemplate(template: SmsCodeRule) {
         viewModelScope.launch {
             val success = withContext(Dispatchers.IO) {
-                EntityStoreManager.storeEntityToFile(getApplication(), EntityType.CODE_RULE_TEMPLATE, template)
+                EntityStoreManager.storeEntityToFile(
+                    getApplication(), EntityType.CODE_RULE_TEMPLATE, template, SmsCodeRule::class.java
+                )
             }
             _eventsFlow.emit(RuleEditEvent.TemplateSaved(success))
         }

--- a/app/src/main/java/com/tianma/xsmscode/ui/rule/list/RuleListViewModel.kt
+++ b/app/src/main/java/com/tianma/xsmscode/ui/rule/list/RuleListViewModel.kt
@@ -126,7 +126,9 @@ class RuleListViewModel(application: Application) : AndroidViewModel(application
     fun saveRulesToFile(rules: List<SmsCodeRule>) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                EntityStoreManager.storeEntitiesToFile(getApplication(), EntityType.CODE_RULES, rules)
+                EntityStoreManager.storeEntitiesToFile(
+                    getApplication(), EntityType.CODE_RULES, rules, SmsCodeRule::class.java
+                )
             }
         }
     }

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/AutoCancelReceiver.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/AutoCancelReceiver.kt
@@ -1,0 +1,33 @@
+package com.tianma.xsmscode.xp.hook.code
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.tianma.xsmscode.common.utils.XLog
+
+/**
+ * Fallback auto-cancel when the module process is not alive.
+ */
+class AutoCancelReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, NOTIFICATION_NONE)
+        if (notificationId == NOTIFICATION_NONE) return
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager?
+        manager?.cancel(notificationId)
+        XLog.i("Notification auto cancelled by alarm, id=%d", notificationId)
+    }
+
+    companion object {
+        const val EXTRA_NOTIFICATION_ID = "extra_notification_id"
+        private const val NOTIFICATION_NONE = -0xff
+
+        fun createIntent(context: Context, notificationId: Int): Intent {
+            return Intent(context, AutoCancelReceiver::class.java).apply {
+                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
@@ -80,21 +80,26 @@ class CodeWorker(
         val operateSmsAction = OperateSmsAction(mPluginContext, mPhoneContext, smsMsg)
         mScheduledExecutor.schedule(operateSmsAction, 3000, TimeUnit.MILLISECONDS)
 
-        // 自杀 Action
-        val killMeAction = KillMeAction(mPluginContext, mPhoneContext, smsMsg)
-        mScheduledExecutor.schedule(killMeAction, 4000, TimeUnit.MILLISECONDS)
-
-        // 自动清除通知
+        var autoCancelRetentionMs = 0L
         if (PrefsReader.autoCancelCodeNotification(mPluginContext)) {
-            val retentionTime = PrefsReader.getNotificationRetentionTime(mPluginContext) * 1000L
+            autoCancelRetentionMs = PrefsReader.getNotificationRetentionTime(mPluginContext) * 1000L
             val notificationId = smsMsg.hashCode()
-            
+
             val cancelNotifyAction = CancelNotifyAction(mPluginContext, mPhoneContext, smsMsg)
             cancelNotifyAction.setNotificationId(notificationId)
 
-            mScheduledExecutor.schedule(cancelNotifyAction, retentionTime, TimeUnit.MILLISECONDS)
-            XLog.d("Scheduled CancelNotifyAction with delay: ${retentionTime}ms for ID: $notificationId")
+            mScheduledExecutor.schedule(cancelNotifyAction, autoCancelRetentionMs, TimeUnit.MILLISECONDS)
+            XLog.d("Scheduled CancelNotifyAction with delay: ${autoCancelRetentionMs}ms for ID: $notificationId")
         }
+
+        // 自杀 Action - delay it if we need time for auto-cancel to fire.
+        val killMeAction = KillMeAction(mPluginContext, mPhoneContext, smsMsg)
+        val killDelayMs = if (autoCancelRetentionMs > 0L) {
+            maxOf(4000L, autoCancelRetentionMs + 500L)
+        } else {
+            4000L
+        }
+        mScheduledExecutor.schedule(killMeAction, killDelayMs, TimeUnit.MILLISECONDS)
 
         mScheduledExecutor.shutdown()
         return buildParseResult()

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
@@ -102,6 +102,7 @@ class CodeWorker(
             XLog.e("Error in notification future get()", e)
         }
 
+        mScheduledExecutor.shutdown()
         return buildParseResult()
     }
 

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CodeWorker.kt
@@ -84,22 +84,16 @@ class CodeWorker(
         val killMeAction = KillMeAction(mPluginContext, mPhoneContext, smsMsg)
         mScheduledExecutor.schedule(killMeAction, 4000, TimeUnit.MILLISECONDS)
 
-        try {
-            // 清除通知
-                val bundle = notificationFuture.get()
-                if (bundle != null && bundle.containsKey(NotifyAction.NOTIFY_RETENTION_TIME)) {
-                    val delay = bundle.getLong(NotifyAction.NOTIFY_RETENTION_TIME, 0L)
-                    val notificationId = bundle.getInt(NotifyAction.NOTIFY_ID, 0)
-                    val cancelNotifyAction = CancelNotifyAction(mPluginContext, mPhoneContext, smsMsg)
-                    cancelNotifyAction.setNotificationId(notificationId)
+        // 自动清除通知
+        if (PrefsReader.autoCancelCodeNotification(mPluginContext)) {
+            val retentionTime = PrefsReader.getNotificationRetentionTime(mPluginContext) * 1000L
+            val notificationId = smsMsg.hashCode()
+            
+            val cancelNotifyAction = CancelNotifyAction(mPluginContext, mPhoneContext, smsMsg)
+            cancelNotifyAction.setNotificationId(notificationId)
 
-                    mScheduledExecutor.schedule(cancelNotifyAction, delay, TimeUnit.MILLISECONDS)
-                    XLog.d("Scheduled CancelNotifyAction with delay: ${delay}ms for ID: $notificationId")
-                } else {
-                    XLog.d("NotifyAction bundle mismatch or missing retention time")
-                }
-        } catch (e: Exception) {
-            XLog.e("Error in notification future get()", e)
+            mScheduledExecutor.schedule(cancelNotifyAction, retentionTime, TimeUnit.MILLISECONDS)
+            XLog.d("Scheduled CancelNotifyAction with delay: ${retentionTime}ms for ID: $notificationId")
         }
 
         mScheduledExecutor.shutdown()

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CopyCodeReceiver.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/CopyCodeReceiver.kt
@@ -21,6 +21,13 @@ class CopyCodeReceiver private constructor() : BroadcastReceiver() {
         val action = intent.action
         if (ACTION_COPY_CODE == action) {
             val smsCode = intent.getStringExtra(EXTRA_KEY_CODE)
+            val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+
+            // cancel notification
+            if (notificationId != -1) {
+                val manager = phoneContext.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager?
+                manager?.cancel(notificationId)
+            }
             // copy to clipboard
             smsCode?.let {
                 ClipboardUtils.copyToClipboard(phoneContext, it)
@@ -57,13 +64,15 @@ class CopyCodeReceiver private constructor() : BroadcastReceiver() {
     companion object {
         private const val ACTION_COPY_CODE = "${BuildConfig.APPLICATION_ID}.ACTION_COPY_CODE"
         private const val EXTRA_KEY_CODE = "extra_key_code"
+        private const val EXTRA_NOTIFICATION_ID = "extra_notification_id"
 
         private val instance: CopyCodeReceiver by lazy { CopyCodeReceiver() }
 
         @JvmStatic
-        fun createIntent(smsCode: String?): Intent {
+        fun createIntent(smsCode: String?, notificationId: Int): Intent {
             val intent = Intent(ACTION_COPY_CODE)
             intent.putExtra(EXTRA_KEY_CODE, smsCode)
+            intent.putExtra(EXTRA_NOTIFICATION_ID, notificationId)
             return intent
         }
 

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/NotifyAction.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/NotifyAction.kt
@@ -1,12 +1,14 @@
 package com.tianma.xsmscode.xp.hook.code.action.impl
 
 import android.annotation.SuppressLint
+import android.app.AlarmManager
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.os.Build
 import android.text.TextUtils
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -15,6 +17,7 @@ import com.tianma.xsmscode.common.constant.NotificationConst
 import com.tianma.xsmscode.common.utils.XLog
 import com.tianma.xsmscode.common.utils.PrefsReader
 import com.tianma.xsmscode.data.db.entity.SmsMsg
+import com.tianma.xsmscode.xp.hook.code.AutoCancelReceiver
 import com.tianma.xsmscode.xp.hook.code.CopyCodeReceiver
 import com.tianma.xsmscode.xp.hook.code.action.CallableAction
 
@@ -51,7 +54,7 @@ class NotifyAction(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE or 0x01000000 // PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT
         )
 
-        val notification = NotificationCompat.Builder(mPluginContext, NotificationConst.CHANNEL_ID_SMSCODE_NOTIFICATION)
+        val builder = NotificationCompat.Builder(mPluginContext, NotificationConst.CHANNEL_ID_SMSCODE_NOTIFICATION)
             .setSmallIcon(R.drawable.ic_app_icon)
             .setLargeIcon(BitmapFactory.decodeResource(mPluginContext.resources, R.drawable.ic_app_icon))
             .setWhen(System.currentTimeMillis())
@@ -61,12 +64,26 @@ class NotifyAction(
             .setAutoCancel(true)
             .setColor(ContextCompat.getColor(mPluginContext, R.color.ic_launcher_background))
             .setGroup(NotificationConst.GROUP_KEY_SMSCODE_NOTIFICATION)
-            .build()
+        
+        val autoCancelEnabled = PrefsReader.autoCancelCodeNotification(mPluginContext)
+        if (autoCancelEnabled) {
+            val retentionTime = PrefsReader.getNotificationRetentionTime(mPluginContext) * 1000L
+            if (retentionTime > 0L) {
+                builder.setTimeoutAfter(retentionTime)
+                scheduleAutoCancel(notificationId, retentionTime)
+            } else {
+                XLog.i("Auto cancel skipped: retentionTimeMs=%d", retentionTime)
+            }
+        } else {
+            XLog.i("Auto cancel disabled")
+        }
+
+        val notification = builder.build()
 
         manager.notify(notificationId, notification)
         XLog.d("Show notification succeed")
 
-        if (PrefsReader.autoCancelCodeNotification(mPluginContext)) {
+        if (autoCancelEnabled) {
             val retentionTime = PrefsReader.getNotificationRetentionTime(mPluginContext) * 1000L
             val bundle = Bundle()
             bundle.putLong(NOTIFY_RETENTION_TIME, retentionTime)
@@ -74,6 +91,31 @@ class NotifyAction(
             return bundle
         }
         return null
+    }
+
+    private fun scheduleAutoCancel(notificationId: Int, retentionTimeMs: Long) {
+        val alarmManager = mPluginContext.getSystemService(Context.ALARM_SERVICE) as AlarmManager? ?: return
+        val appUid = mPluginContext.applicationInfo?.uid ?: -1
+        if (android.os.Process.myUid() != appUid) {
+            XLog.i("Skip alarm auto cancel: uid=%d, appUid=%d", android.os.Process.myUid(), appUid)
+            return
+        }
+        val intent = AutoCancelReceiver.createIntent(mPluginContext, notificationId)
+        val pendingIntent = PendingIntent.getBroadcast(
+            mPluginContext,
+            notificationId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val triggerAt = System.currentTimeMillis() + retentionTimeMs
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+        } else {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+        }
+        XLog.i("Schedule auto cancel alarm, id=%d, delayMs=%d", notificationId, retentionTimeMs)
     }
 
     companion object {

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/NotifyAction.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/NotifyAction.kt
@@ -45,7 +45,7 @@ class NotifyAction(
 
         val notificationId = smsMsg.hashCode()
 
-        val copyCodeIntent = CopyCodeReceiver.createIntent(smsCode)
+        val copyCodeIntent = CopyCodeReceiver.createIntent(smsCode, notificationId)
         val contentIntent = PendingIntent.getBroadcast(
             mPhoneContext, 0, copyCodeIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE or 0x01000000 // PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT

--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/SmsParseAction.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/SmsParseAction.kt
@@ -95,7 +95,7 @@ class SmsParseAction(
                 }
             }
             // 保存当前验证码记录 Action
-            EntityStoreManager.storeEntityToFile(mPluginContext, EntityType.PREV_SMS_MSG, mSmsMsg)
+            EntityStoreManager.storeEntityToFile(mPluginContext, EntityType.PREV_SMS_MSG, mSmsMsg, SmsMsg::class.java)
         }
 
         bundle.putBoolean(SMS_DUPLICATED, duplicated)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -67,6 +67,7 @@
     <string name="notification_retention_time_30_secs_entry">30 秒</string>
     <string name="notification_retention_time_1_min_entry">1 分钟</string>
     <string name="notification_retention_time_5_mins_entry">5 分钟</string>
+    <string name="pref_sync_toast">设置已保存</string>
     <!-- notification retention time end -->
     <!-- preference code notification -->
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -67,6 +67,7 @@
     <string name="notification_retention_time_30_secs_entry">30 秒</string>
     <string name="notification_retention_time_1_min_entry">1 分鐘</string>
     <string name="notification_retention_time_5_mins_entry">5 分鐘</string>
+    <string name="pref_sync_toast">設定已儲存</string>
     <!-- notification retention time end -->
     <!-- preference code notification -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="dialog_donate_cancel">Next Time</string>
     <string name="long_press_save_hint">Long press image to save to gallery</string>
     <string name="save_to_gallery_success">Image saved to gallery, opening %s...</string>
+    <string name="pref_sync_toast">Settings saved</string>
     <string name="save_to_gallery_failed">Save failed, please check file permissions</string>
     <string name="save_to_gallery">Save to Gallery</string>
     <!-- alipay packet end -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidx-material3" }
+androidx-material = { group = "androidx.compose.material", name = "material" }
 androidx-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }

--- a/storage/src/main/java/com/tianma/xsmscode/common/utils/JsonUtils.kt
+++ b/storage/src/main/java/com/tianma/xsmscode/common/utils/JsonUtils.kt
@@ -65,4 +65,10 @@ object JsonUtils {
         val jsonString = reader.readText()
         return listFromJson(jsonString, entityClass)
     }
+    @JvmStatic
+    fun <T : Any> listToJson(list: List<T>, entityClass: Class<T>): String {
+        @Suppress("UNCHECKED_CAST")
+        val entitySerializer = serializer(entityClass) as KSerializer<T>
+        return json.encodeToString(ListSerializer(entitySerializer), list)
+    }
 }


### PR DESCRIPTION
- handle empty entity files
- add swipe to delete for code records
- sync settings to shared prefs and expose provider
- improve notification auto-cancel handling
- add random debug version suffix

## Summary by Sourcery

将应用设置与新的共享首选项提供器同步，增强通知的自动取消行为，并提升实体存储和验证码记录管理的健壮性。

New Features:
- 通过内容提供器对外暴露首选项，以支持跨进程访问，并可通过 `PrefsReader` 进行读取。
- 在历史记录页面为验证码记录新增「滑动删除」并支持撤销操作。
- 引入基于闹钟的后备接收器，即使模块进程不存活也能自动取消通知。
- 在调试构建的版本号后追加随机十六进制后缀，便于区分不同版本。

Bug Fixes:
- 安全处理空的实体存储文件，避免解析错误。
- 在执行复制操作时，确保短信验证码通知被正确取消。
- 调整通知自动取消和自终止的时间点，避免竞态条件和取消遗漏。

Enhancements:
- 将 DataStore 中的首选项同步到一个全局可读的 shared preferences 文件中，并确保两种存储方式都保持可读。
- 从 UI 将设置变更同步回 shared preferences，并通过确认 Toast 提示用户。
- 优化实体文件写入方式，通过截断并显式序列化列表来写入文件，并对 JSON 序列化辅助方法进行抽象与通用化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize app settings with a new shared preferences provider, enhance notification auto-cancel behavior, and improve robustness of entity storage and code record management.

New Features:
- Expose preferences via a content provider for cross-process access and reading through PrefsReader.
- Add swipe-to-delete with undo support for code records in the history screen.
- Introduce an alarm-based fallback receiver to auto-cancel notifications even when the module process is not alive.
- Append a random hex suffix to debug build version names for easier differentiation.

Bug Fixes:
- Handle empty entity store files safely to avoid parsing errors.
- Ensure SMS code notifications are cancelled when the copy action is triggered.
- Adjust notification auto-cancel and self-termination timing to avoid race conditions and missed cancellations.

Enhancements:
- Sync DataStore preferences into a world-readable shared preferences file and ensure both storages remain readable.
- Propagate settings changes to shared preferences from the UI and inform users with a confirmation toast.
- Refine entity file writing by truncating and serializing lists explicitly, and generalize JSON serialization helpers.

</details>