### PR TITLE
feat: format Time field in forwarded messages

### DIFF
--- a/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/ForwardAction.kt
+++ b/app/src/main/java/com/tianma/xsmscode/xp/hook/code/action/impl/ForwardAction.kt
@@ -18,6 +18,9 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.json.JSONObject
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 /**
@@ -166,7 +169,7 @@ class ForwardAction(pluginContext: Context, phoneContext: Context, smsMsg: SmsMs
                 if (!mSmsMsg.company.isNullOrBlank()) {
                     append('\n').append("Company: ").append(mSmsMsg.company)
                 }
-                append('\n').append("Time: ").append(mSmsMsg.date)
+                append('\n').append("Time: ").append(formatDate(mSmsMsg.date))
             }
             if (!isCodeSms) {
                 append(mSmsMsg.body.orEmpty())
@@ -229,6 +232,10 @@ class ForwardAction(pluginContext: Context, phoneContext: Context, smsMsg: SmsMs
         }.getOrDefault(false)
     }
 
+    private fun formatDate(timestamp: Long): String {
+        return SimpleDateFormat("yyyy.MM.dd HH:mm:ss", Locale.getDefault()).format(Date(timestamp))
+    }
+
     private fun forwardToTelegram(
         botToken: String,
         chatId: String,
@@ -244,7 +251,7 @@ class ForwardAction(pluginContext: Context, phoneContext: Context, smsMsg: SmsMs
                 if (!mSmsMsg.company.isNullOrBlank()) {
                     append('\n').append("Company: ").append(mSmsMsg.company)
                 }
-                append('\n').append("Time: ").append(mSmsMsg.date)
+                append('\n').append("Time: ").append(formatDate(mSmsMsg.date))
             }
             if (!isCodeSms) {
                 append(mSmsMsg.body.orEmpty())


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 在转发的消息中，将短信日期字段格式化为人类可读的 `yyyy.MM.dd HH:mm:ss` 格式，而不是使用原始时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Format the SMS date field in forwarded messages using a human-readable yyyy.MM.dd HH:mm:ss pattern instead of the raw timestamp.

</details>