### PR TITLE
build: update forced dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,6 @@ buildscript {
     configurations.all {
         resolutionStrategy {
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
-            force("io.netty:netty-codec:4.2.12.Final")
-            force("io.netty:netty-codec-http:4.2.12.Final")
-            force("io.netty:netty-codec-http2:4.2.12.Final")
-            force("io.netty:netty-common:4.2.12.Final")
-            force("io.netty:netty-handler:4.2.12.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")
@@ -118,11 +113,6 @@ subprojects {
         resolutionStrategy {
             force(catalog.apache.httpclient)
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
-            force("io.netty:netty-codec:4.2.12.Final")
-            force("io.netty:netty-codec-http:4.2.12.Final")
-            force("io.netty:netty-codec-http2:4.2.12.Final")
-            force("io.netty:netty-common:4.2.12.Final")
-            force("io.netty:netty-handler:4.2.12.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")


### PR DESCRIPTION
Automated dependency force maintenance:
- Removed force rules when natural resolution already matches forced versions.
- Added or updated force rules for dependencies with open security alerts (Dependabot).

## Summary by Sourcery

Build:
- 移除对 Netty 构件多余的强制规则，这些构件现在已默认解析为所需版本，无需再强制指定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Remove redundant force rules for Netty artifacts now resolved at the desired versions by default.

</details>