### PR TITLE
build: update forced dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,11 @@ buildscript {
     configurations.all {
         resolutionStrategy {
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
+            force("io.netty:netty-codec:4.1.125.Final")
+            force("io.netty:netty-codec-http:4.1.132.Final")
+            force("io.netty:netty-codec-http2:4.1.132.Final")
+            force("io.netty:netty-common:4.1.118.Final")
+            force("io.netty:netty-handler:4.1.118.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")
@@ -113,6 +118,11 @@ subprojects {
         resolutionStrategy {
             force(catalog.apache.httpclient)
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
+            force("io.netty:netty-codec:4.1.125.Final")
+            force("io.netty:netty-codec-http:4.1.132.Final")
+            force("io.netty:netty-codec-http2:4.1.132.Final")
+            force("io.netty:netty-common:4.1.118.Final")
+            force("io.netty:netty-handler:4.1.118.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")


### PR DESCRIPTION
Automated dependency force maintenance:
- Removed force rules when natural resolution already matches forced versions.
- Added or updated force rules for dependencies with open security alerts (Dependabot).
- Refreshed committed Gradle dependency lockfiles after dependency graph changes.

## Summary by Sourcery

通过 Gradle 解析策略统一对齐 Netty 依赖版本，在 buildscript 和所有子项目中强制使用安全、一致的版本。

Bug Fixes:
- 通过在 Gradle 构建中强制指定特定的 Netty 模块版本，缓解安全警报。

Enhancements:
- 在根项目和子项目的 Gradle 配置中标准化强制使用的 Netty 依赖版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Netty dependency versions via Gradle resolution strategy to enforce secure, consistent versions across buildscript and subprojects.

Bug Fixes:
- Mitigate security alerts by forcing specific Netty module versions in the Gradle build.

Enhancements:
- Standardize forced Netty dependency versions in both root and subproject Gradle configurations.

</details>