### PR TITLE
build: update forced dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,6 @@ buildscript {
     configurations.all {
         resolutionStrategy {
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
-            force("io.netty:netty-codec:4.2.12.Final")
-            force("io.netty:netty-codec-http:4.2.12.Final")
-            force("io.netty:netty-codec-http2:4.2.12.Final")
-            force("io.netty:netty-common:4.2.12.Final")
-            force("io.netty:netty-handler:4.2.12.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")
@@ -118,11 +113,6 @@ subprojects {
         resolutionStrategy {
             force(catalog.apache.httpclient)
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
-            force("io.netty:netty-codec:4.2.12.Final")
-            force("io.netty:netty-codec-http:4.2.12.Final")
-            force("io.netty:netty-codec-http2:4.2.12.Final")
-            force("io.netty:netty-common:4.2.12.Final")
-            force("io.netty:netty-handler:4.2.12.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")


### PR DESCRIPTION
Automated dependency force maintenance:
- Removed force rules when natural resolution already matches forced versions.
- Added or updated force rules for dependencies with open security alerts (Dependabot).
- Refreshed committed Gradle dependency lockfiles after dependency graph changes.

## Summary by Sourcery

改进内容：
- 从 Gradle 解析策略中移除多余的 Netty 强制规则，在自然的依赖解析已经能提供所需版本的情况下不再强制指定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove redundant Netty force rules from Gradle resolution strategy where natural dependency resolution already provides the desired versions.

</details>