### PR TITLE
build: update forced dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,11 @@ buildscript {
     configurations.all {
         resolutionStrategy {
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
+            force("io.netty:netty-codec:4.1.125.Final")
+            force("io.netty:netty-codec-http:4.1.132.Final")
+            force("io.netty:netty-codec-http2:4.1.132.Final")
+            force("io.netty:netty-common:4.1.118.Final")
+            force("io.netty:netty-handler:4.1.118.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")
@@ -113,6 +118,11 @@ subprojects {
         resolutionStrategy {
             force(catalog.apache.httpclient)
             // BEGIN AUTO FORCED DEPENDENCIES (managed by workflow)
+            force("io.netty:netty-codec:4.1.125.Final")
+            force("io.netty:netty-codec-http:4.1.132.Final")
+            force("io.netty:netty-codec-http2:4.1.132.Final")
+            force("io.netty:netty-common:4.1.118.Final")
+            force("io.netty:netty-handler:4.1.118.Final")
             force("org.apache.commons:commons-lang3:3.20.0")
             force("org.bitbucket.b_c:jose4j:0.9.6")
             force("org.bouncycastle:bcpkix-jdk18on:1.84")


### PR DESCRIPTION
Automated dependency force maintenance:
- Removed force rules when natural resolution already matches forced versions.
- Added or updated force rules for dependencies with open security alerts (Dependabot).
- Refreshed committed Gradle dependency lockfiles after dependency graph changes.

## Summary by Sourcery

Build:
- 在根项目和子项目的配置中，添加 Gradle 解析策略规则，以强制统一使用一致版本的 Netty codec、HTTP、HTTP/2、common 和 handler 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add Gradle resolution strategy rules to force consistent versions of Netty codec, HTTP, HTTP/2, common, and handler modules in root and subproject configurations.

</details>